### PR TITLE
Update for new Ruby and Rails versions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
-        with:
+        # with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
           # config-name: my-config.yml
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,36 @@ language: ruby
 rvm:
 - 2.5
 - 2.6
+- 2.7
+- 3.0
+- 3.1
 
 env:
   matrix:
     - RAILS_VERSION="~> 4.1"
     - RAILS_VERSION="~> 5.2"
     - RAILS_VERSION="~> 6.0.0"
+    - RAILS_VERSION="~> 6.1"
+    - RAILS_VERSION="~> 7.0.0"
+
+jobs:
+  exclude:
+  - rvm: 2.5
+    env: RAILS_VERSION="~> 7.0.0"
+  - rvm: 2.6
+    env: RAILS_VERSION="~> 7.0.0"
+  - rvm: 2.7
+    env: RAILS_VERSION="~> 4.1"
+  - rvm: 3.0
+    env: RAILS_VERSION="~> 4.1"
+  - rvm: 3.0
+    env: RAILS_VERSION="~> 5.2"
+  - rvm: 3.1
+    env: RAILS_VERSION="~> 4.1"
+  - rvm: 3.1
+    env: RAILS_VERSION="~> 5.2"
+  - rvm: 3.1
+    env: RAILS_VERSION="~> 6.0.0"
 
 cache: bundler
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Create PDFs using plain old HTML+CSS. Uses [wkhtmltopdf](http://github.com/antia
 
 ## Supported versions
 
-- Ruby 2.5, 2.6
-- Rails 4.2, 5.2, 6.0
+- Ruby 2.5, 2.6, 2.7, 3.0, 3.1
+- Rails 4.2, 5.2, 6.0, 6.1, 7.0
 
 ## Install
 

--- a/lib/pdfkit.rb
+++ b/lib/pdfkit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pdfkit/source'
 require 'pdfkit/pdfkit'
 require 'pdfkit/middleware'

--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PDFKit
   class Configuration
     attr_accessor :meta_tag_prefix, :root_url
@@ -26,7 +28,7 @@ class PDFKit
 
     def default_wkhtmltopdf
       return @default_command_path if @default_command_path
-      if defined?(Bundler::GemfileError) && File.exists?('Gemfile')
+      if defined?(Bundler::GemfileError) && File.exist?('Gemfile')
         @default_command_path = `bundle exec which wkhtmltopdf`.chomp.lines.last
       end
       @default_command_path = `which wkhtmltopdf`.chomp if @default_command_path.nil? || @default_command_path.empty?

--- a/lib/pdfkit/html_preprocessor.rb
+++ b/lib/pdfkit/html_preprocessor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PDFKit
   module HTMLPreprocessor
 

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PDFKit
   class Middleware
     def initialize(app, options = {}, conditions = {})

--- a/lib/pdfkit/os.rb
+++ b/lib/pdfkit/os.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rbconfig'
 
 class PDFKit

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'shellwords'
 require 'tempfile'
 
@@ -6,8 +8,8 @@ class PDFKit
 
   class NoExecutableError < Error
     def initialize
-      msg  = "No wkhtmltopdf executable found at #{PDFKit.configuration.wkhtmltopdf}\n"
-      msg << ">> Please install wkhtmltopdf - https://github.com/pdfkit/PDFKit/wiki/Installing-WKHTMLTOPDF"
+      msg = "No wkhtmltopdf executable found at #{PDFKit.configuration.wkhtmltopdf}\n" \
+            ">> Please install wkhtmltopdf - https://github.com/pdfkit/PDFKit/wiki/Installing-WKHTMLTOPDF"
       super(msg)
     end
   end
@@ -40,7 +42,7 @@ class PDFKit
     @renderer = WkHTMLtoPDF.new options
     @renderer.normalize_options
 
-    raise NoExecutableError unless File.exists?(PDFKit.configuration.wkhtmltopdf)
+    raise NoExecutableError unless File.exist?(PDFKit.configuration.wkhtmltopdf)
   end
 
   def command(path = nil)

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 require 'uri'
 
@@ -7,6 +9,8 @@ class PDFKit
 
     def initialize(url_file_or_html)
       @source = url_file_or_html
+      # @source is assumed to be modifiable, so make sure it is.
+      @source = @source.dup if @source.is_a?(String) && @source.frozen?
     end
 
     def url?
@@ -38,11 +42,11 @@ class PDFKit
     private
 
     def shell_safe_url
-      url_needs_escaping? ? URI::escape(@source) : @source
+      url_needs_escaping? ? URI::DEFAULT_PARSER.escape(@source) : @source
     end
 
     def url_needs_escaping?
-      URI::decode(@source) == @source
+      URI::DEFAULT_PARSER.unescape(@source) == @source
     end
   end
 end

--- a/lib/pdfkit/version.rb
+++ b/lib/pdfkit/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PDFKit
   VERSION = '0.8.5'
 end

--- a/lib/pdfkit/wkhtmltopdf.rb
+++ b/lib/pdfkit/wkhtmltopdf.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class PDFKit
   class WkHTMLtoPDF
     attr_reader :options
     # Pulled from:
     # https://github.com/wkhtmltopdf/wkhtmltopdf/blob/ebf9b6cfc4c58a31349fb94c568b254fac37b3d3/README_WKHTMLTOIMAGE#L27
-    REPEATABLE_OPTIONS = %w[--allow --cookie --custom-header --post --post-file --run-script]
-    SPECIAL_OPTIONS = %w[cover toc]
+    REPEATABLE_OPTIONS = %w[--allow --cookie --custom-header --post --post-file --run-script].freeze
+    SPECIAL_OPTIONS = %w[cover toc].freeze
 
     def initialize(options)
       @options = options

--- a/pdfkit.gemspec
+++ b/pdfkit.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<activesupport>, [">= 4.1.11"])
   s.add_development_dependency(%q<mocha>, [">= 0.9.10"])
   s.add_development_dependency(%q<rack-test>, [">= 0.5.6"])
-  s.add_development_dependency(%q<rake>, ["~>12.3.3"])
-  s.add_development_dependency(%q<rdoc>, ["~> 4.0.1"])
+  s.add_development_dependency(%q<rake>, [">= 12.3.3"])
+  s.add_development_dependency(%q<rdoc>, [">= 4.0.1"])
   s.add_development_dependency(%q<rspec>, ["~> 3.0"])
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PDFKit::Configuration do

--- a/spec/html_preprocessor_spec.rb
+++ b/spec/html_preprocessor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PDFKit::HTMLPreprocessor do

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 def app; Rack::Lint.new(@app); end
@@ -267,8 +269,8 @@ describe PDFKit::Middleware do
       describe "saving generated pdf to disk" do
         before do
           #make sure tests don't find an old test_save.pdf
-          File.delete('spec/test_save.pdf') if File.exists?('spec/test_save.pdf')
-          expect(File.exists?('spec/test_save.pdf')).to eq(false)
+          File.delete('spec/test_save.pdf') if File.exist?('spec/test_save.pdf')
+          expect(File.exist?('spec/test_save.pdf')).to eq(false)
         end
 
         context "when header PDFKit-save-pdf is present" do
@@ -276,7 +278,7 @@ describe PDFKit::Middleware do
             headers = { 'PDFKit-save-pdf' => 'spec/test_save.pdf' }
             mock_app({}, {only: '/public'}, headers)
             get 'http://www.example.org/public/test_save.pdf'
-            expect(File.exists?('spec/test_save.pdf')).to eq(true)
+            expect(File.exist?('spec/test_save.pdf')).to eq(true)
           end
 
           it "does not raise when target directory does not exist" do
@@ -292,7 +294,7 @@ describe PDFKit::Middleware do
           it "does not saved the .pdf to disk" do
             mock_app({}, {only: '/public'}, {} )
             get 'http://www.example.org/public/test_save.pdf'
-            expect(File.exists?('spec/test_save.pdf')).to eq(false)
+            expect(File.exist?('spec/test_save.pdf')).to eq(false)
           end
         end
       end

--- a/spec/os_spec.rb
+++ b/spec/os_spec.rb
@@ -1,4 +1,6 @@
 #encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'rbconfig'
 

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -1,4 +1,6 @@
 #encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PDFKit do
@@ -27,7 +29,7 @@ describe PDFKit do
       file_path = File.join(SPEC_ROOT,'fixtures','example.html')
       pdfkit = PDFKit.new(Tempfile.new(file_path))
       expect(pdfkit.source).to be_file
-      expect(pdfkit.source.to_s).to match /^#{Dir.tmpdir}/
+      expect(pdfkit.source.to_s).to match(/^#{Dir.tmpdir}/)
     end
 
     # Options
@@ -239,12 +241,12 @@ describe PDFKit do
 
     it "read the source from stdin if it is html" do
       pdfkit = PDFKit.new('html')
-      expect(pdfkit.command).to match /- -$/
+      expect(pdfkit.command).to match(/- -$/)
     end
 
     it "specifies the URL to the source if it is a url" do
       pdfkit = PDFKit.new('http://google.com')
-      expect(pdfkit.command).to match /"http:\/\/google.com" -$/
+      expect(pdfkit.command).to match(/"http:\/\/google.com" -$/)
     end
 
     it "does not break Windows paths" do
@@ -256,19 +258,19 @@ describe PDFKit do
     it "specifies the path to the source if it is a file" do
       file_path = File.join(SPEC_ROOT,'fixtures','example.html')
       pdfkit = PDFKit.new(File.new(file_path))
-      expect(pdfkit.command).to match /#{file_path} -$/
+      expect(pdfkit.command).to match(/#{file_path} -$/)
     end
 
     it "specifies the path to the source if it is a tempfile" do
       file_path = File.join(SPEC_ROOT,'fixtures','example.html')
       pdfkit = PDFKit.new(Tempfile.new(file_path))
-      expect(pdfkit.command).to match /#{Dir.tmpdir}\S+ -$/
+      expect(pdfkit.command).to match(/#{Dir.tmpdir}\S+ -$/)
     end
 
     it "specifies the path for the ouput if a path is given" do
       file_path = "/path/to/output.pdf"
       pdfkit = PDFKit.new("html")
-      expect(pdfkit.command(file_path)).to match /#{file_path}$/
+      expect(pdfkit.command(file_path)).to match(/#{file_path}$/)
     end
 
     it "detects special pdfkit meta tags" do

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PDFKit::Source do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 SPEC_ROOT = File.dirname(__FILE__)
 $LOAD_PATH.unshift(SPEC_ROOT)
 $LOAD_PATH.unshift(File.join(SPEC_ROOT, '..', 'lib'))
@@ -6,13 +8,15 @@ SimpleCov.start do
   add_filter 'spec/'
 end
 
+Warning[:deprecated] = true if defined?(Warning.[]=)
+
 require 'pdfkit'
 require 'rspec'
 require 'mocha'
 require 'rack'
 require 'rack/test'
 require 'active_support'
-require 'custom_wkhtmltopdf_path' if File.exists?(File.join(SPEC_ROOT, 'custom_wkhtmltopdf_path.rb'))
+require 'custom_wkhtmltopdf_path' if File.exist?(File.join(SPEC_ROOT, 'custom_wkhtmltopdf_path.rb'))
 
 RSpec.configure do |config|
   include Rack::Test::Methods


### PR DESCRIPTION
- Test Ruby 2.7, 3.0, and 3.1, and Rails 6.1 and 7.0.
- Exclude incompatible test matrix combinations.
- Show Ruby deprecation warnings in tests where supported.
- File.exists? is deprecated; use File.exist?.
- URI.escape and URI.decode are deprecated.
- Add frozen string literal comments.
- Make sure constants are frozen.
- Make sure that the code is frozen-string safe.
- Adjust dev dependencies for Ruby 3.0+ compatibility.
- Fix Ruby warnings in pdfkit_spec.rb
- Comment out bad syntax in release-drafter action.

Fixes #498